### PR TITLE
Remove no-longer needed database dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.4
 click==7.1.2
-databases==0.4.3
 dnspython==2.1.0
 email-validator==1.1.3
 fastapi==0.68.0
@@ -35,7 +34,6 @@ PyYAML==5.4.1
 requests==2.26.0
 Rx==1.6.1
 six==1.16.0
-SQLAlchemy==1.3.24
 starlette==0.14.2
 typing-extensions==3.10.0.0
 ujson==4.0.2


### PR DESCRIPTION
Database dependencies now live in TheDataStation/database_service
and are versioned slightly differently. The database dependencies
specified there were conflicting with these removed dependencies,
which made it awkward to install both user_register and
database_service in the same virtualenv.